### PR TITLE
bug fix: ignore negative resistance

### DIFF
--- a/deeac/adapters/topology/eurostag/dtos/transformer.py
+++ b/deeac/adapters/topology/eurostag/dtos/transformer.py
@@ -46,7 +46,7 @@ class Type1Transformer(Transformer):
     """
     Data of a transformer with fixed real ratio (type 1).
     """
-    resistance: NonNegativeFloat
+    resistance: float
     reactance: float
     rated_apparent_power: float
     transformation_ratio: PositiveFloat


### PR DESCRIPTION
bug fix: ignore negative resistance in ech file for type 1 transformers (resistance is taken from lf file)